### PR TITLE
Better standard way to place cascade removers in graph

### DIFF
--- a/Executable/Platformer2dDemo/Game/Application/Application.cpp
+++ b/Executable/Platformer2dDemo/Game/Application/Application.cpp
@@ -98,7 +98,6 @@ DemoScenarioExecutor::DemoScenarioExecutor (Emergence::Celerity::TaskConstructor
           EDIT_VALUE_2F (Emergence::Celerity::UniformVector4fValue, assetId, uniformName))
 {
     _constructor.DependOn (Emergence::Celerity::AssetManagement::Checkpoint::FINISHED);
-    _constructor.DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.DependOn (Emergence::Celerity::TransformVisualSync::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Emergence::Celerity::RenderPipelineFoundation::Checkpoint::RENDER_STARTED);
 }

--- a/Executable/Platformer2dDemo/Game/Application/Application.cpp
+++ b/Executable/Platformer2dDemo/Game/Application/Application.cpp
@@ -97,8 +97,9 @@ DemoScenarioExecutor::DemoScenarioExecutor (Emergence::Celerity::TaskConstructor
       editUniformVector4fByAssetIdAndName (
           EDIT_VALUE_2F (Emergence::Celerity::UniformVector4fValue, assetId, uniformName))
 {
-    _constructor.DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::DETACHMENT_DETECTION_FINISHED);
     _constructor.DependOn (Emergence::Celerity::AssetManagement::Checkpoint::FINISHED);
+    _constructor.DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
+    _constructor.DependOn (Emergence::Celerity::TransformVisualSync::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Emergence::Celerity::RenderPipelineFoundation::Checkpoint::RENDER_STARTED);
 }
 

--- a/Executable/Platformer2dDemo/Game/Application/Application.cpp
+++ b/Executable/Platformer2dDemo/Game/Application/Application.cpp
@@ -322,6 +322,7 @@ void Application::InitWorld () noexcept
         Emergence::Celerity::RegisterRender2dEvents (registrar);
         Emergence::Celerity::RegisterRenderFoundationEvents (registrar);
         Emergence::Celerity::RegisterTransform2dEvents (registrar);
+        Emergence::Celerity::RegisterTransformCommonEvents (registrar);
     }
 
     Emergence::Celerity::PipelineBuilder pipelineBuilder {&world};

--- a/Executable/SpaceShooterDemo/Game/Main.cpp
+++ b/Executable/SpaceShooterDemo/Game/Main.cpp
@@ -154,6 +154,7 @@ void GameApplication::Start ()
         Emergence::Celerity::RegisterAssemblyEvents (registrar);
         Emergence::Celerity::RegisterPhysicsEvents (registrar);
         Emergence::Celerity::RegisterTransform3dEvents (registrar);
+        Emergence::Celerity::RegisterTransformCommonEvents (registrar);
         RegisterGameplayEvents (registrar);
         RegisterRenderEvents (registrar);
     }

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/Movement.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/Movement.cpp
@@ -166,7 +166,7 @@ void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) n
         .AS_CASCADE_REMOVER_1F (DeathFixedEvent, MovementComponent, objectId)
         .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
 
-    _pipelineBuilder.AddTask ("Movement::RemoveAfterTransformRemoval"_us)
+    _pipelineBuilder.AddTask ("Movement::RemoveOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, MovementComponent, objectId)
         .DependOn ("Movement::RemoveAfterDeath"_us)
         .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/Movement.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/Movement.cpp
@@ -7,8 +7,8 @@
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Transform/Events.hpp>
 #include <Celerity/Transform/TransformComponent.hpp>
-#include <Celerity/Transform/TransformWorldAccessor.hpp>
 #include <Celerity/Transform/TransformHierarchyCleanup.hpp>
+#include <Celerity/Transform/TransformWorldAccessor.hpp>
 
 #include <Gameplay/Events.hpp>
 #include <Gameplay/InputConstant.hpp>

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/NonFeatureSpecificComponentCleanup.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/NonFeatureSpecificComponentCleanup.cpp
@@ -1,6 +1,7 @@
 #include <Celerity/Assembly/Assembly.hpp>
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Transform/Events.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 
 #include <Gameplay/AlignmentComponent.hpp>
 #include <Gameplay/NonFeatureSpecificComponentCleanup.hpp>
@@ -9,20 +10,11 @@ namespace NonFeatureSpecificComponentCleanup
 {
 using namespace Emergence::Memory::Literals;
 
-const Emergence::Memory::UniqueString Checkpoint::STARTED {"NonFeatureSpecificComponentCleanupStarted"};
-const Emergence::Memory::UniqueString Checkpoint::FINISHED {"NonFeatureSpecificComponentCleanupFinished"};
-
 void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) noexcept
 {
-    auto visualGroup = _pipelineBuilder.OpenVisualGroup ("NonFeatureSpecificComponentCleanup");
-    _pipelineBuilder.AddCheckpoint (Checkpoint::STARTED);
-    _pipelineBuilder.AddCheckpoint (Checkpoint::FINISHED);
-
     _pipelineBuilder.AddTask ("NonFutureSpecificComponentCleanup::AlignmentComponent"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform3dComponentRemovedFixedEvent, AlignmentComponent,
-                                objectId)
-        .DependOn (Checkpoint::STARTED)
-        .MakeDependencyOf (Checkpoint::FINISHED)
-        .MakeDependencyOf (Emergence::Celerity::Assembly::Checkpoint::STARTED);
+        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, AlignmentComponent, objectId)
+        .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
+        .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
 }
 } // namespace NonFeatureSpecificComponentCleanup

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/NonFeatureSpecificComponentCleanup.hpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/NonFeatureSpecificComponentCleanup.hpp
@@ -4,13 +4,5 @@
 
 namespace NonFeatureSpecificComponentCleanup
 {
-struct Checkpoint final
-{
-    Checkpoint () = delete;
-
-    static const Emergence::Memory::UniqueString STARTED;
-    static const Emergence::Memory::UniqueString FINISHED;
-};
-
 void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) noexcept;
 } // namespace NonFeatureSpecificComponentCleanup

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/RandomAi.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/RandomAi.cpp
@@ -185,7 +185,7 @@ void InputGenerator::Execute () noexcept
 
 void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) noexcept
 {
-    _pipelineBuilder.AddTask ("RandomAi::RemoveAfterTransformRemoval"_us)
+    _pipelineBuilder.AddTask ("RandomAi::RemoveOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, RandomAiComponent, objectId)
         .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/RandomAi.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/RandomAi.cpp
@@ -7,6 +7,7 @@
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Transform/Events.hpp>
 #include <Celerity/Transform/TransformComponent.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 #include <Celerity/Transform/TransformWorldAccessor.hpp>
 
 #include <Gameplay/AlignmentComponent.hpp>
@@ -184,13 +185,13 @@ void InputGenerator::Execute () noexcept
 
 void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) noexcept
 {
+    _pipelineBuilder.AddTask ("RandomAi::RemoveAfterTransformRemoval"_us)
+        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, RandomAiComponent, objectId)
+        .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
+        .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
+
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("RandomAi");
     _pipelineBuilder.AddTask ("RandomAi::AttachmentCreator"_us).SetExecutor<AttachmentCreator> ();
-
-    _pipelineBuilder.AddTask ("RandomAi::RemoveAfterTransformRemoval"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform3dComponentRemovedFixedEvent, RandomAiComponent, objectId)
-        .MakeDependencyOf ("RandomAi::InputGenerator"_us);
-
     _pipelineBuilder.AddTask ("RandomAi::InputGenerator"_us).SetExecutor<InputGenerator> ();
 }
 } // namespace RandomAi

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/Shooting.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/Shooting.cpp
@@ -132,7 +132,7 @@ void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) n
         .AS_CASCADE_REMOVER_1F (DeathFixedEvent, ShooterComponent, objectId)
         .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
 
-    _pipelineBuilder.AddTask ("Shooting::RemoveAfterTransformRemoval"_us)
+    _pipelineBuilder.AddTask ("Shooting::RemoveOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, ShooterComponent, objectId)
         .DependOn ("Shooting::RemoveAfterDeath"_us)
         .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/Spawn.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/Spawn.cpp
@@ -89,8 +89,7 @@ void SpawnProcessor::Execute () noexcept
     const auto *world = static_cast<const Emergence::Celerity::WorldSingleton *> (*worldCursor);
 
     for (auto eventCursor = fetchTransformCleanupEvents.Execute ();
-         const auto *event =
-             static_cast<const Emergence::Celerity::TransformNodeCleanupFixedEvent *> (*eventCursor);
+         const auto *event = static_cast<const Emergence::Celerity::TransformNodeCleanupFixedEvent *> (*eventCursor);
          ++eventCursor)
     {
         // If deleted transform was spawned, clear it from owner spawn.

--- a/Executable/SpaceShooterDemo/Shared/Gameplay/Spawn.cpp
+++ b/Executable/SpaceShooterDemo/Shared/Gameplay/Spawn.cpp
@@ -5,10 +5,10 @@
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Transform/Events.hpp>
 #include <Celerity/Transform/TransformComponent.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 #include <Celerity/Transform/TransformWorldAccessor.hpp>
 
 #include <Gameplay/AlignmentComponent.hpp>
-#include <Gameplay/NonFeatureSpecificComponentCleanup.hpp>
 #include <Gameplay/Spawn.hpp>
 #include <Gameplay/SpawnComponent.hpp>
 
@@ -32,7 +32,7 @@ private:
     Emergence::Celerity::FetchSingletonQuery fetchTime;
     Emergence::Celerity::FetchSingletonQuery fetchWorld;
 
-    Emergence::Celerity::FetchSequenceQuery fetchTransformRemovedEvents;
+    Emergence::Celerity::FetchSequenceQuery fetchTransformCleanupEvents;
 
     Emergence::Celerity::RemoveValueQuery removeSpawnById;
     Emergence::Celerity::ModifyAscendingRangeQuery modifySpawnByCoolingDownUntil;
@@ -51,7 +51,8 @@ SpawnProcessor::SpawnProcessor (Emergence::Celerity::TaskConstructor &_construct
     : fetchTime (FETCH_SINGLETON (Emergence::Celerity::TimeSingleton)),
       fetchWorld (FETCH_SINGLETON (Emergence::Celerity::WorldSingleton)),
 
-      fetchTransformRemovedEvents (FETCH_SEQUENCE (Emergence::Celerity::Transform3dComponentRemovedFixedEvent)),
+      // We use transform cleanup instead of transform removal, because it makes easier to position task in graph.
+      fetchTransformCleanupEvents (FETCH_SEQUENCE (Emergence::Celerity::TransformNodeCleanupFixedEvent)),
 
       removeSpawnById (REMOVE_VALUE_1F (SpawnComponent, objectId)),
       modifySpawnByCoolingDownUntil (MODIFY_ASCENDING_RANGE (SpawnComponent, spawnCoolingDownUntilNs)),
@@ -74,7 +75,7 @@ SpawnProcessor::SpawnProcessor (Emergence::Celerity::TaskConstructor &_construct
       insertAlignment (INSERT_LONG_TERM (AlignmentComponent))
 {
     _constructor.DependOn (Checkpoint::STARTED);
-    _constructor.DependOn (NonFeatureSpecificComponentCleanup::Checkpoint::FINISHED);
+    _constructor.DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Emergence::Celerity::Assembly::Checkpoint::STARTED);
 }
@@ -87,9 +88,9 @@ void SpawnProcessor::Execute () noexcept
     auto worldCursor = fetchWorld.Execute ();
     const auto *world = static_cast<const Emergence::Celerity::WorldSingleton *> (*worldCursor);
 
-    for (auto eventCursor = fetchTransformRemovedEvents.Execute ();
+    for (auto eventCursor = fetchTransformCleanupEvents.Execute ();
          const auto *event =
-             static_cast<const Emergence::Celerity::Transform3dComponentRemovedFixedEvent *> (*eventCursor);
+             static_cast<const Emergence::Celerity::TransformNodeCleanupFixedEvent *> (*eventCursor);
          ++eventCursor)
     {
         // If deleted transform was spawned, clear it from owner spawn.
@@ -178,15 +179,14 @@ void SpawnProcessor::Execute () noexcept
 
 void AddToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder) noexcept
 {
+    _pipelineBuilder.AddTask ("Spawn::RemoveSpawns"_us)
+        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::TransformNodeCleanupFixedEvent, SpawnComponent, objectId)
+        .DependOn (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
+        .MakeDependencyOf (Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::FINISHED);
+
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("Spawn");
     _pipelineBuilder.AddCheckpoint (Checkpoint::STARTED);
     _pipelineBuilder.AddCheckpoint (Checkpoint::FINISHED);
-
-    _pipelineBuilder.AddTask ("Spawn::RemoveSpawns"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform3dComponentRemovedFixedEvent, SpawnComponent, objectId)
-        .DependOn (Checkpoint::STARTED)
-        .MakeDependencyOf ("Spawn::Process"_us);
-
     _pipelineBuilder.AddTask ("Spawn::Process"_us).SetExecutor<SpawnProcessor> ();
 }
 } // namespace Spawn

--- a/Library/Public/Celerity/Extension/Input/Celerity/Input/Input.cpp
+++ b/Library/Public/Celerity/Extension/Input/Celerity/Input/Input.cpp
@@ -277,7 +277,7 @@ void AddToFixedUpdate (PipelineBuilder &_builder) noexcept
 {
     using namespace Memory::Literals;
 
-    _builder.AddTask ("CleanupInputSubscriptionComponentAfterTransformRemoval"_us)
+    _builder.AddTask ("RemoveInputSubscriptionComponentOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedEvent, InputSubscriptionComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
@@ -291,7 +291,7 @@ void AddToNormalUpdate (PipelineBuilder &_builder, FrameInputAccumulator *_input
 {
     using namespace Memory::Literals;
 
-    _builder.AddTask ("CleanupInputSubscriptionComponentAfterTransformRemoval"_us)
+    _builder.AddTask ("RemoveInputSubscriptionComponentOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, InputSubscriptionComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
@@ -378,12 +378,12 @@ using namespace Memory::Literals;
 
 void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
 {
-    _pipelineBuilder.AddTask ("CleanupRenderObject2dAfterTransformRemovalFromNormal"_us)
+    _pipelineBuilder.AddTask ("RemoveRenderObject2dOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, RenderObject2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
-    _pipelineBuilder.AddTask ("CleanupLocalBounds2dAfterTransformRemovalFromNormal"_us)
+    _pipelineBuilder.AddTask ("RemoveLocalBounds2dOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, LocalBounds2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
@@ -378,33 +378,29 @@ using namespace Memory::Literals;
 
 void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
 {
-    auto visualGroup = _pipelineBuilder.OpenVisualGroup ("BoundsCalculation2d");
-    _pipelineBuilder.AddCheckpoint (Checkpoint::STARTED);
-    _pipelineBuilder.AddCheckpoint (Checkpoint::FINISHED);
-
     _pipelineBuilder.AddTask ("CleanupRenderObject2dAfterTransformRemovalFromNormal"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform2dComponentRemovedNormalEvent, RenderObject2dComponent,
-                                objectId)
-        .DependOn (Checkpoint::STARTED)
-        .DependOn (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED)
+        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, RenderObject2dComponent, objectId)
+        .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
+        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
         .MakeDependencyOf ("CleanupRenderObject2dAfterTransformRemovalFromFixed"_us);
 
     _pipelineBuilder.AddTask ("CleanupRenderObject2dAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform2dComponentRemovedFixedToNormalEvent,
-                                RenderObject2dComponent, objectId)
-        .MakeDependencyOf ("Render2dBoundsCalculator"_us);
+        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, RenderObject2dComponent, objectId)
+        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     _pipelineBuilder.AddTask ("CleanupLocalBounds2dAfterTransformRemovalFromNormal"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform2dComponentRemovedNormalEvent, LocalBounds2dComponent,
-                                objectId)
-        .DependOn (Checkpoint::STARTED)
-        .DependOn (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED)
+        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, LocalBounds2dComponent, objectId)
+        .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
+        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
         .MakeDependencyOf ("CleanupLocalBounds2dAfterTransformRemovalFromFixed"_us);
 
     _pipelineBuilder.AddTask ("CleanupLocalBounds2dAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (Emergence::Celerity::Transform2dComponentRemovedFixedToNormalEvent,
-                                LocalBounds2dComponent, objectId)
-        .MakeDependencyOf ("Render2dBoundsCalculator"_us);
+        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, LocalBounds2dComponent, objectId)
+        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
+
+    auto visualGroup = _pipelineBuilder.OpenVisualGroup ("BoundsCalculation2d");
+    _pipelineBuilder.AddCheckpoint (Checkpoint::STARTED);
+    _pipelineBuilder.AddCheckpoint (Checkpoint::FINISHED);
 
     _pipelineBuilder.AddTask ("Render2dBoundsCalculator"_us).SetExecutor<BoundsCalculator> ();
 }

--- a/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Private/Celerity/Render/2d/BoundsCalculation2d.cpp
@@ -381,21 +381,11 @@ void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
     _pipelineBuilder.AddTask ("CleanupRenderObject2dAfterTransformRemovalFromNormal"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, RenderObject2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
-        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
-        .MakeDependencyOf ("CleanupRenderObject2dAfterTransformRemovalFromFixed"_us);
-
-    _pipelineBuilder.AddTask ("CleanupRenderObject2dAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, RenderObject2dComponent, objectId)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     _pipelineBuilder.AddTask ("CleanupLocalBounds2dAfterTransformRemovalFromNormal"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, LocalBounds2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
-        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
-        .MakeDependencyOf ("CleanupLocalBounds2dAfterTransformRemovalFromFixed"_us);
-
-    _pipelineBuilder.AddTask ("CleanupLocalBounds2dAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, LocalBounds2dComponent, objectId)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("BoundsCalculation2d");

--- a/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
@@ -1,3 +1,4 @@
+#include <Celerity/Asset/AssetManagement.hpp>
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Render/2d/BoundsCalculation2d.hpp>
 #include <Celerity/Render/2d/Camera2dComponent.hpp>
@@ -6,7 +7,6 @@
 #include <Celerity/Render/2d/WorldRendering2d.hpp>
 #include <Celerity/Transform/Events.hpp>
 #include <Celerity/Transform/TransformHierarchyCleanup.hpp>
-#include <Celerity/Asset/AssetManagement.hpp>
 
 namespace Emergence::Celerity::Rendering2d
 {
@@ -25,7 +25,7 @@ void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder, const Math::AxisAlign
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
         // We delay removal processing in asset management by one frame, because otherwise
         // we won't be able to delete Sprite2dComponent after AssetManagement.
-        .DependOn(AssetManagement::Checkpoint::FINISHED);
+        .DependOn (AssetManagement::Checkpoint::FINISHED);
 
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("Rendering2d");
     BoundsCalculation2d::AddToNormalUpdate (_pipelineBuilder);

--- a/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
@@ -17,11 +17,6 @@ void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder, const Math::AxisAlign
     _pipelineBuilder.AddTask ("CleanupCamera2dComponentAfterTransformRemovalFromNormal"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, Camera2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
-        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
-        .MakeDependencyOf ("CleanupCamera2dComponentAfterTransformRemovalFromFixed"_us);
-
-    _pipelineBuilder.AddTask ("CleanupCamera2dComponentAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, Camera2dComponent, objectId)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     _pipelineBuilder.AddTask ("CleanupSprite2dComponentAfterTransformRemovalFromNormal"_us)
@@ -30,12 +25,7 @@ void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder, const Math::AxisAlign
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)
         // We delay removal processing in asset management by one frame, because otherwise
         // we won't be able to delete Sprite2dComponent after AssetManagement.
-        .DependOn(AssetManagement::Checkpoint::FINISHED)
-        .MakeDependencyOf ("CleanupSprite2dComponentAfterTransformRemovalFromFixed"_us);
-
-    _pipelineBuilder.AddTask ("CleanupSprite2dComponentAfterTransformRemovalFromFixed"_us)
-        .AS_CASCADE_REMOVER_1F (TransformNodeCleanupFixedToNormalEvent, Sprite2dComponent, objectId)
-        .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
+        .DependOn(AssetManagement::Checkpoint::FINISHED);
 
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("Rendering2d");
     BoundsCalculation2d::AddToNormalUpdate (_pipelineBuilder);

--- a/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
+++ b/Library/Public/Celerity/Extension/Render2d/Public/Celerity/Render/2d/Rendering2d.cpp
@@ -14,12 +14,12 @@ void AddToNormalUpdate (PipelineBuilder &_pipelineBuilder, const Math::AxisAlign
 {
     using namespace Memory::Literals;
 
-    _pipelineBuilder.AddTask ("CleanupCamera2dComponentAfterTransformRemovalFromNormal"_us)
+    _pipelineBuilder.AddTask ("RemoveCamera2dComponentOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, Camera2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
-    _pipelineBuilder.AddTask ("CleanupSprite2dComponentAfterTransformRemovalFromNormal"_us)
+    _pipelineBuilder.AddTask ("RemoveSprite2dComponentOnTransformCleanup"_us)
         .AS_CASCADE_REMOVER_1F (TransformNodeCleanupNormalEvent, Sprite2dComponent, objectId)
         .DependOn (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED)
         .MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::FINISHED)

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.cpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.cpp
@@ -4,25 +4,29 @@
 namespace Emergence::Celerity
 {
 #define IMPLEMENT_TRANSFORM_EVENTS(Dimension)                                                                          \
-    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentAddedFixedToNormalEvent, objectId);      \
-    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentAddedNormalEvent, objectId);             \
+    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentAddedFixedToNormalEvent, objectId)       \
+    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentAddedNormalEvent, objectId)              \
                                                                                                                        \
     EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (                                                                         \
         Transform##Dimension##dComponentVisualLocalTransformChangedFixedToNormalEvent, objectId);                      \
     EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentVisualLocalTransformChangedNormalEvent,  \
-                                              objectId);                                                               \
+                                              objectId)                                                                \
                                                                                                                        \
     EMERGENCE_CELERITY_EVENT2_IMPLEMENTATION (Transform##Dimension##dComponentParentChangedFixedToNormalEvent,         \
-                                              objectId, oldParentId);                                                  \
+                                              objectId, oldParentId)                                                   \
     EMERGENCE_CELERITY_EVENT2_IMPLEMENTATION (Transform##Dimension##dComponentParentChangedNormalEvent, objectId,      \
-                                              oldParentId);                                                            \
+                                              oldParentId)                                                             \
                                                                                                                        \
-    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedFixedEvent, objectId);            \
-    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedNormalEvent, objectId);           \
-    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedFixedToNormalEvent, objectId);
+    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedFixedEvent, objectId)             \
+    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedNormalEvent, objectId)            \
+    EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (Transform##Dimension##dComponentRemovedFixedToNormalEvent, objectId)
 
 IMPLEMENT_TRANSFORM_EVENTS (2)
 IMPLEMENT_TRANSFORM_EVENTS (3)
+
+EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupFixedEvent, objectId)
+EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupFixedToNormalEvent, objectId)
+EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupNormalEvent, objectId)
 
 #define REGISTER_TRANSFORM_EVENTS(Dimension)                                                                           \
     _registrar.OnAddEvent ({{Transform##Dimension##dComponentAddedFixedToNormalEvent::Reflect ().mapping,              \
@@ -100,5 +104,13 @@ void RegisterTransform2dEvents (EventRegistrar &_registrar) noexcept
 void RegisterTransform3dEvents (EventRegistrar &_registrar) noexcept
 {
     REGISTER_TRANSFORM_EVENTS (3);
+}
+
+void RegisterTransformCommonEvents (EventRegistrar &_registrar) noexcept
+{
+    _registrar.CustomEvent ({TransformNodeCleanupFixedEvent::Reflect ().mapping, EventRoute::FIXED});
+    _registrar.CustomEvent (
+        {TransformNodeCleanupFixedToNormalEvent::Reflect ().mapping, EventRoute::FROM_FIXED_TO_NORMAL});
+    _registrar.CustomEvent ({TransformNodeCleanupNormalEvent::Reflect ().mapping, EventRoute::NORMAL});
 }
 } // namespace Emergence::Celerity

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.cpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.cpp
@@ -25,8 +25,7 @@ IMPLEMENT_TRANSFORM_EVENTS (2)
 IMPLEMENT_TRANSFORM_EVENTS (3)
 
 EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupFixedEvent, objectId)
-EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupFixedToNormalEvent, objectId)
-EMERGENCE_CELERITY_EVENT1_IMPLEMENTATION (TransformNodeCleanupNormalEvent, objectId)
+EMERGENCE_CELERITY_EVENT2_IMPLEMENTATION (TransformNodeCleanupNormalEvent, objectId, cleanupTransform)
 
 #define REGISTER_TRANSFORM_EVENTS(Dimension)                                                                           \
     _registrar.OnAddEvent ({{Transform##Dimension##dComponentAddedFixedToNormalEvent::Reflect ().mapping,              \
@@ -109,8 +108,6 @@ void RegisterTransform3dEvents (EventRegistrar &_registrar) noexcept
 void RegisterTransformCommonEvents (EventRegistrar &_registrar) noexcept
 {
     _registrar.CustomEvent ({TransformNodeCleanupFixedEvent::Reflect ().mapping, EventRoute::FIXED});
-    _registrar.CustomEvent (
-        {TransformNodeCleanupFixedToNormalEvent::Reflect ().mapping, EventRoute::FROM_FIXED_TO_NORMAL});
     _registrar.CustomEvent ({TransformNodeCleanupNormalEvent::Reflect ().mapping, EventRoute::NORMAL});
 }
 } // namespace Emergence::Celerity

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.hpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.hpp
@@ -30,8 +30,7 @@ DECLARE_TRANSFORM_EVENTS (2)
 DECLARE_TRANSFORM_EVENTS (3)
 
 EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupFixedEvent, UniqueId, objectId);
-EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupFixedToNormalEvent, UniqueId, objectId);
-EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupNormalEvent, UniqueId, objectId);
+EMERGENCE_CELERITY_EVENT2_DECLARATION (TransformNodeCleanupNormalEvent, UniqueId, objectId, bool, cleanupTransform);
 
 void RegisterTransform2dEvents (EventRegistrar &_registrar) noexcept;
 

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.hpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/Events.hpp
@@ -29,7 +29,13 @@ namespace Emergence::Celerity
 DECLARE_TRANSFORM_EVENTS (2)
 DECLARE_TRANSFORM_EVENTS (3)
 
+EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupFixedEvent, UniqueId, objectId);
+EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupFixedToNormalEvent, UniqueId, objectId);
+EMERGENCE_CELERITY_EVENT1_DECLARATION (TransformNodeCleanupNormalEvent, UniqueId, objectId);
+
 void RegisterTransform2dEvents (EventRegistrar &_registrar) noexcept;
 
 void RegisterTransform3dEvents (EventRegistrar &_registrar) noexcept;
+
+void RegisterTransformCommonEvents (EventRegistrar &_registrar) noexcept;
 } // namespace Emergence::Celerity

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformHierarchyCleanup.cpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformHierarchyCleanup.cpp
@@ -15,7 +15,7 @@ namespace Tasks
 {
 static const Memory::UniqueString CLEANUP_SCHEDULER {"TransformHierarchyCleanup::CleanupScheduler"};
 
-static const Memory::UniqueString TRANSFORM_CLEANER {"TransformHierarchyCleanup::TransformCleaner"};
+static const Memory::UniqueString TRANSFORM_CLEANER {"TransformHierarchyCleanup::FixedTransformCleaner"};
 } // namespace Tasks
 
 struct TransformCleanedUpMarkerComponent final
@@ -43,87 +43,138 @@ const TransformCleanedUpMarkerComponent::Reflection &TransformCleanedUpMarkerCom
     return reflection;
 }
 
-class CleanupScheduler final : public TaskExecutorBase<CleanupScheduler>
+#define SCHEDULERS(Dimensions)                                                                                         \
+    class FixedCleanup##Dimensions##dScheduler final : public TaskExecutorBase<FixedCleanup##Dimensions##dScheduler>   \
+    {                                                                                                                  \
+    public:                                                                                                            \
+        FixedCleanup##Dimensions##dScheduler (TaskConstructor &_constructor) noexcept;                                 \
+                                                                                                                       \
+        void Execute () noexcept;                                                                                      \
+                                                                                                                       \
+    private:                                                                                                           \
+        void ScheduleCleanup (InsertShortTermQuery::Cursor &_insertionCursor, UniqueId _objectId) noexcept;            \
+                                                                                                                       \
+        FetchSequenceQuery fetchRemovalEvents;                                                                         \
+        FetchValueQuery fetchComponentByParent;                                                                        \
+        RemoveValueQuery removeTransformCleanedUpMarker;                                                               \
+        InsertShortTermQuery insertCleanupEvent;                                                                       \
+    };                                                                                                                 \
+                                                                                                                       \
+    FixedCleanup##Dimensions##dScheduler::FixedCleanup##Dimensions##dScheduler (                                       \
+        TaskConstructor &_constructor) noexcept                                                                        \
+        : fetchRemovalEvents (FETCH_SEQUENCE (Transform##Dimensions##dComponentRemovedFixedEvent)),                    \
+          fetchComponentByParent (FETCH_VALUE_1F (Transform##Dimensions##dComponent, parentObjectId)),                 \
+          removeTransformCleanedUpMarker (REMOVE_VALUE_1F (TransformCleanedUpMarkerComponent, objectId)),              \
+          insertCleanupEvent (INSERT_SHORT_TERM (TransformNodeCleanupFixedEvent))                                      \
+    {                                                                                                                  \
+        _constructor.DependOn (Checkpoint::STARTED);                                                                   \
+        _constructor.MakeDependencyOf (Checkpoint::CLEANUP_STARTED);                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    void FixedCleanup##Dimensions##dScheduler::Execute () noexcept                                                     \
+    {                                                                                                                  \
+        auto insertionCursor = insertCleanupEvent.Execute ();                                                          \
+        for (auto removalEventCursor = fetchRemovalEvents.Execute ();                                                  \
+             const auto *removedId = static_cast<const UniqueId *> (*removalEventCursor); ++removalEventCursor)        \
+        {                                                                                                              \
+            ScheduleCleanup (insertionCursor, *removedId);                                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+                                                                                                                       \
+    void FixedCleanup##Dimensions##dScheduler::ScheduleCleanup (InsertShortTermQuery::Cursor &_insertionCursor,        \
+                                                                UniqueId _objectId) noexcept                           \
+    {                                                                                                                  \
+        if (auto cursor = removeTransformCleanedUpMarker.Execute (&_objectId); cursor.ReadConst ())                    \
+        {                                                                                                              \
+            /* Transform was removed by cleanup logic, therefore cleanup already happened. */                          \
+            ~cursor;                                                                                                   \
+            return;                                                                                                    \
+        }                                                                                                              \
+                                                                                                                       \
+        *static_cast<TransformNodeCleanupFixedEvent *> (++_insertionCursor) = {_objectId};                             \
+        for (auto childCursor = fetchComponentByParent.Execute (&_objectId);                                           \
+             const auto *component = static_cast<const Transform##Dimensions##dComponent *> (*childCursor);            \
+             ++childCursor)                                                                                            \
+        {                                                                                                              \
+            ScheduleCleanup (_insertionCursor, component->GetObjectId ());                                             \
+        }                                                                                                              \
+    }                                                                                                                  \
+                                                                                                                       \
+    class NormalCleanup##Dimensions##dScheduler final : public TaskExecutorBase<NormalCleanup##Dimensions##dScheduler> \
+    {                                                                                                                  \
+    public:                                                                                                            \
+        NormalCleanup##Dimensions##dScheduler (TaskConstructor &_constructor) noexcept;                                \
+                                                                                                                       \
+        void Execute () noexcept;                                                                                      \
+                                                                                                                       \
+    private:                                                                                                           \
+        void ScheduleCleanup (InsertShortTermQuery::Cursor &_insertionCursor,                                          \
+                              UniqueId _objectId,                                                                      \
+                              bool _cleanupTransform) noexcept;                                                        \
+                                                                                                                       \
+        FetchSequenceQuery fetchFixedRemovalEvents;                                                                    \
+        FetchSequenceQuery fetchNormalRemovalEvents;                                                                   \
+        FetchValueQuery fetchComponentByParent;                                                                        \
+        RemoveValueQuery removeTransformCleanedUpMarker;                                                               \
+        InsertShortTermQuery insertCleanupEvent;                                                                       \
+    };                                                                                                                 \
+                                                                                                                       \
+    NormalCleanup##Dimensions##dScheduler::NormalCleanup##Dimensions##dScheduler (                                     \
+        TaskConstructor &_constructor) noexcept                                                                        \
+        : fetchFixedRemovalEvents (FETCH_SEQUENCE (Transform##Dimensions##dComponentRemovedFixedToNormalEvent)),       \
+          fetchNormalRemovalEvents (FETCH_SEQUENCE (Transform##Dimensions##dComponentRemovedNormalEvent)),             \
+          fetchComponentByParent (FETCH_VALUE_1F (Transform##Dimensions##dComponent, parentObjectId)),                 \
+          removeTransformCleanedUpMarker (REMOVE_VALUE_1F (TransformCleanedUpMarkerComponent, objectId)),              \
+          insertCleanupEvent (INSERT_SHORT_TERM (TransformNodeCleanupNormalEvent))                                     \
+    {                                                                                                                  \
+        _constructor.DependOn (Checkpoint::STARTED);                                                                   \
+        _constructor.MakeDependencyOf (Checkpoint::CLEANUP_STARTED);                                                   \
+    }                                                                                                                  \
+                                                                                                                       \
+    void NormalCleanup##Dimensions##dScheduler::Execute () noexcept                                                    \
+    {                                                                                                                  \
+        auto insertionCursor = insertCleanupEvent.Execute ();                                                          \
+        for (auto removalEventCursor = fetchFixedRemovalEvents.Execute ();                                             \
+             const auto *removedId = static_cast<const UniqueId *> (*removalEventCursor); ++removalEventCursor)        \
+        {                                                                                                              \
+            ScheduleCleanup (insertionCursor, *removedId, false);                                                      \
+        }                                                                                                              \
+                                                                                                                       \
+        for (auto removalEventCursor = fetchNormalRemovalEvents.Execute ();                                            \
+             const auto *removedId = static_cast<const UniqueId *> (*removalEventCursor); ++removalEventCursor)        \
+        {                                                                                                              \
+            ScheduleCleanup (insertionCursor, *removedId, true);                                                       \
+        }                                                                                                              \
+    }                                                                                                                  \
+                                                                                                                       \
+    void NormalCleanup##Dimensions##dScheduler::ScheduleCleanup (InsertShortTermQuery::Cursor &_insertionCursor,       \
+                                                                 UniqueId _objectId, bool _cleanupTransform) noexcept  \
+    {                                                                                                                  \
+        if (auto cursor = removeTransformCleanedUpMarker.Execute (&_objectId); cursor.ReadConst ())                    \
+        {                                                                                                              \
+            /* Transform was removed by cleanup logic, therefore cleanup already happened. */                          \
+            ~cursor;                                                                                                   \
+            return;                                                                                                    \
+        }                                                                                                              \
+                                                                                                                       \
+        *static_cast<TransformNodeCleanupNormalEvent *> (++_insertionCursor) = {_objectId, _cleanupTransform};         \
+        for (auto childCursor = fetchComponentByParent.Execute (&_objectId);                                           \
+             const auto *component = static_cast<const Transform##Dimensions##dComponent *> (*childCursor);            \
+             ++childCursor)                                                                                            \
+        {                                                                                                              \
+            ScheduleCleanup (_insertionCursor, component->GetObjectId (), _cleanupTransform);                          \
+        }                                                                                                              \
+    }
+
+SCHEDULERS (2)
+SCHEDULERS (3)
+
+class FixedTransformCleaner final : public TaskExecutorBase<FixedTransformCleaner>
 {
 public:
-    CleanupScheduler (TaskConstructor &_constructor,
-                      const StandardLayout::Mapping &_componentMapping,
-                      StandardLayout::FieldId _idField,
-                      StandardLayout::FieldId _parentField,
-                      const StandardLayout::Mapping &_removalEventMapping,
-                      const Container::Vector<StandardLayout::Mapping> &_cleanupEventMappings) noexcept;
-
-    void Execute () noexcept;
-
-private:
-    void ScheduleCleanup (UniqueId _objectId) noexcept;
-
-    FetchSequenceQuery fetchRemovalEvents;
-    FetchValueQuery fetchComponentByParent;
-    RemoveValueQuery removeTransformCleanedUpMarker;
-    Container::Vector<InsertShortTermQuery> insertCleanupEvent {Memory::Profiler::AllocationGroup::Top ()};
-    StandardLayout::Field componentObjectIdField;
-};
-
-CleanupScheduler::CleanupScheduler (TaskConstructor &_constructor,
-                                    const StandardLayout::Mapping &_componentMapping,
-                                    StandardLayout::FieldId _idField,
-                                    StandardLayout::FieldId _parentField,
-                                    const StandardLayout::Mapping &_removalEventMapping,
-                                    const Container::Vector<StandardLayout::Mapping> &_cleanupEventMappings) noexcept
-    : fetchRemovalEvents (_constructor.FetchSequence (_removalEventMapping)),
-      fetchComponentByParent (_constructor.FetchValue (_componentMapping, {_parentField})),
-      removeTransformCleanedUpMarker (REMOVE_VALUE_1F (TransformCleanedUpMarkerComponent, objectId)),
-      componentObjectIdField (_componentMapping.GetField (_idField))
-{
-    insertCleanupEvent.reserve (_cleanupEventMappings.size ());
-    for (const StandardLayout::Mapping &mapping : _cleanupEventMappings)
-    {
-        insertCleanupEvent.emplace_back (_constructor.InsertShortTerm (mapping));
-    }
-
-    _constructor.DependOn (Checkpoint::STARTED);
-    _constructor.MakeDependencyOf (Checkpoint::CLEANUP_STARTED);
-}
-
-void CleanupScheduler::Execute () noexcept
-{
-    for (auto removalEventCursor = fetchRemovalEvents.Execute ();
-         const auto *removedId = static_cast<const UniqueId *> (*removalEventCursor); ++removalEventCursor)
-    {
-        ScheduleCleanup (*removedId);
-    }
-}
-
-void CleanupScheduler::ScheduleCleanup (UniqueId _objectId) noexcept
-{
-    if (auto cursor = removeTransformCleanedUpMarker.Execute (&_objectId); cursor.ReadConst ())
-    {
-        // Transform was removed by cleanup logic, therefore cleanup already happened.
-        ~cursor;
-        return;
-    }
-
-    for (auto &query : insertCleanupEvent)
-    {
-        auto cursor = query.Execute ();
-        *static_cast<UniqueId *> (++cursor) = _objectId;
-    }
-
-    for (auto childCursor = fetchComponentByParent.Execute (&_objectId); const void *component = *childCursor;
-         ++childCursor)
-    {
-        ScheduleCleanup (*static_cast<const UniqueId *> (componentObjectIdField.GetValue (component)));
-    }
-}
-
-class TransformCleaner final : public TaskExecutorBase<TransformCleaner>
-{
-public:
-    TransformCleaner (TaskConstructor &_constructor,
-                      const StandardLayout::Mapping &_componentMapping,
-                      StandardLayout::FieldId _idField,
-                      const StandardLayout::Mapping &_cleanupEventMapping) noexcept;
+    FixedTransformCleaner (TaskConstructor &_constructor,
+                           const StandardLayout::Mapping &_componentMapping,
+                           StandardLayout::FieldId _idField) noexcept;
 
     void Execute () noexcept;
 
@@ -133,11 +184,10 @@ private:
     InsertLongTermQuery insertTransformCleanedUpMarker;
 };
 
-TransformCleaner::TransformCleaner (TaskConstructor &_constructor,
-                                    const StandardLayout::Mapping &_componentMapping,
-                                    StandardLayout::FieldId _idField,
-                                    const StandardLayout::Mapping &_cleanupEventMapping) noexcept
-    : fetchCleanupEvents (_constructor.FetchSequence (_cleanupEventMapping)),
+FixedTransformCleaner::FixedTransformCleaner (TaskConstructor &_constructor,
+                                              const StandardLayout::Mapping &_componentMapping,
+                                              StandardLayout::FieldId _idField) noexcept
+    : fetchCleanupEvents (FETCH_SEQUENCE (TransformNodeCleanupFixedEvent)),
       removeComponentById (_constructor.RemoveValue (_componentMapping, {_idField})),
       insertTransformCleanedUpMarker (INSERT_LONG_TERM (TransformCleanedUpMarkerComponent))
 {
@@ -145,16 +195,59 @@ TransformCleaner::TransformCleaner (TaskConstructor &_constructor,
     _constructor.MakeDependencyOf (Checkpoint::FINISHED);
 }
 
-void TransformCleaner::Execute () noexcept
+void FixedTransformCleaner::Execute () noexcept
 {
     auto markerCursor = insertTransformCleanedUpMarker.Execute ();
     for (auto eventCursor = fetchCleanupEvents.Execute ();
-         const auto *cleanupId = static_cast<const UniqueId *> (*eventCursor); ++eventCursor)
+         const auto *event = static_cast<const TransformNodeCleanupFixedEvent *> (*eventCursor); ++eventCursor)
     {
-        if (auto removalCursor = removeComponentById.Execute (cleanupId); removalCursor.ReadConst ())
+        if (auto removalCursor = removeComponentById.Execute (&event->objectId); removalCursor.ReadConst ())
         {
             ~removalCursor;
-            static_cast<TransformCleanedUpMarkerComponent *> (++markerCursor)->objectId = *cleanupId;
+            static_cast<TransformCleanedUpMarkerComponent *> (++markerCursor)->objectId = event->objectId;
+        }
+    }
+}
+
+class NormalTransformCleaner final : public TaskExecutorBase<NormalTransformCleaner>
+{
+public:
+    NormalTransformCleaner (TaskConstructor &_constructor,
+                            const StandardLayout::Mapping &_componentMapping,
+                            StandardLayout::FieldId _idField) noexcept;
+
+    void Execute () noexcept;
+
+private:
+    FetchSequenceQuery fetchCleanupEvents;
+    RemoveValueQuery removeComponentById;
+    InsertLongTermQuery insertTransformCleanedUpMarker;
+};
+
+NormalTransformCleaner::NormalTransformCleaner (TaskConstructor &_constructor,
+                                                const StandardLayout::Mapping &_componentMapping,
+                                                StandardLayout::FieldId _idField) noexcept
+    : fetchCleanupEvents (FETCH_SEQUENCE (TransformNodeCleanupNormalEvent)),
+      removeComponentById (_constructor.RemoveValue (_componentMapping, {_idField})),
+      insertTransformCleanedUpMarker (INSERT_LONG_TERM (TransformCleanedUpMarkerComponent))
+{
+    _constructor.DependOn (Checkpoint::CLEANUP_STARTED);
+    _constructor.MakeDependencyOf (Checkpoint::FINISHED);
+}
+
+void NormalTransformCleaner::Execute () noexcept
+{
+    auto markerCursor = insertTransformCleanedUpMarker.Execute ();
+    for (auto eventCursor = fetchCleanupEvents.Execute ();
+         const auto *event = static_cast<const TransformNodeCleanupNormalEvent *> (*eventCursor); ++eventCursor)
+    {
+        if (event->cleanupTransform)
+        {
+            if (auto removalCursor = removeComponentById.Execute (&event->objectId); removalCursor.ReadConst ())
+            {
+                ~removalCursor;
+                static_cast<TransformCleanedUpMarkerComponent *> (++markerCursor)->objectId = event->objectId;
+            }
         }
     }
 }
@@ -171,19 +264,10 @@ void Add2dToFixedUpdate (PipelineBuilder &_pipelineBuilder) noexcept
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("TransformHierarchyCleanup");
     AddCheckpoints (_pipelineBuilder);
 
-    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER)
-        .SetExecutor<CleanupScheduler> (
-            Transform2dComponent::Reflect ().mapping, Transform2dComponent::Reflect ().objectId,
-            Transform2dComponent::Reflect ().parentObjectId, Transform2dComponentRemovedFixedEvent::Reflect ().mapping,
-            Container::Vector<StandardLayout::Mapping> {
-                TransformNodeCleanupFixedEvent::Reflect ().mapping,
-                TransformNodeCleanupFixedToNormalEvent::Reflect ().mapping,
-            });
-
+    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER).SetExecutor<FixedCleanup2dScheduler> ();
     _pipelineBuilder.AddTask (Tasks::TRANSFORM_CLEANER)
-        .SetExecutor<TransformCleaner> (Transform2dComponent::Reflect ().mapping,
-                                        Transform2dComponent::Reflect ().objectId,
-                                        TransformNodeCleanupFixedEvent::Reflect ().mapping);
+        .SetExecutor<FixedTransformCleaner> (Transform2dComponent::Reflect ().mapping,
+                                             Transform2dComponent::Reflect ().objectId);
 }
 
 void Add2dToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
@@ -191,38 +275,21 @@ void Add2dToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("TransformHierarchyCleanup");
     AddCheckpoints (_pipelineBuilder);
 
-    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER)
-        .SetExecutor<CleanupScheduler> (
-            Transform2dComponent::Reflect ().mapping, Transform2dComponent::Reflect ().objectId,
-            Transform2dComponent::Reflect ().parentObjectId, Transform2dComponentRemovedNormalEvent::Reflect ().mapping,
-            Container::Vector<StandardLayout::Mapping> {
-                TransformNodeCleanupNormalEvent::Reflect ().mapping,
-            });
-
+    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER).SetExecutor<NormalCleanup2dScheduler> ();
     _pipelineBuilder.AddTask (Tasks::TRANSFORM_CLEANER)
-        .SetExecutor<TransformCleaner> (Transform2dComponent::Reflect ().mapping,
-                                        Transform2dComponent::Reflect ().objectId,
-                                        TransformNodeCleanupNormalEvent::Reflect ().mapping);
+        .SetExecutor<NormalTransformCleaner> (Transform2dComponent::Reflect ().mapping,
+                                              Transform2dComponent::Reflect ().objectId);
 }
 
 void Add3dToFixedUpdate (PipelineBuilder &_pipelineBuilder) noexcept
 {
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("TransformHierarchyCleanup");
     AddCheckpoints (_pipelineBuilder);
-    
-    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER)
-        .SetExecutor<CleanupScheduler> (
-            Transform3dComponent::Reflect ().mapping, Transform3dComponent::Reflect ().objectId,
-            Transform3dComponent::Reflect ().parentObjectId, Transform3dComponentRemovedFixedEvent::Reflect ().mapping,
-            Container::Vector<StandardLayout::Mapping> {
-                TransformNodeCleanupFixedEvent::Reflect ().mapping,
-                TransformNodeCleanupFixedToNormalEvent::Reflect ().mapping,
-            });
 
+    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER).SetExecutor<FixedCleanup3dScheduler> ();
     _pipelineBuilder.AddTask (Tasks::TRANSFORM_CLEANER)
-        .SetExecutor<TransformCleaner> (Transform3dComponent::Reflect ().mapping,
-                                        Transform3dComponent::Reflect ().objectId,
-                                        TransformNodeCleanupFixedEvent::Reflect ().mapping);
+        .SetExecutor<FixedTransformCleaner> (Transform3dComponent::Reflect ().mapping,
+                                             Transform3dComponent::Reflect ().objectId);
 }
 
 void Add3dToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
@@ -230,17 +297,10 @@ void Add3dToNormalUpdate (PipelineBuilder &_pipelineBuilder) noexcept
     auto visualGroup = _pipelineBuilder.OpenVisualGroup ("TransformHierarchyCleanup");
     AddCheckpoints (_pipelineBuilder);
 
-    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER)
-        .SetExecutor<CleanupScheduler> (
-            Transform3dComponent::Reflect ().mapping, Transform3dComponent::Reflect ().objectId,
-            Transform3dComponent::Reflect ().parentObjectId, Transform3dComponentRemovedNormalEvent::Reflect ().mapping,
-            Container::Vector<StandardLayout::Mapping> {
-                TransformNodeCleanupNormalEvent::Reflect ().mapping,
-            });
+    _pipelineBuilder.AddTask (Tasks::CLEANUP_SCHEDULER).SetExecutor<NormalCleanup3dScheduler> ();
 
     _pipelineBuilder.AddTask (Tasks::TRANSFORM_CLEANER)
-        .SetExecutor<TransformCleaner> (Transform3dComponent::Reflect ().mapping,
-                                        Transform3dComponent::Reflect ().objectId,
-                                        TransformNodeCleanupNormalEvent::Reflect ().mapping);
+        .SetExecutor<NormalTransformCleaner> (Transform3dComponent::Reflect ().mapping,
+                                              Transform3dComponent::Reflect ().objectId);
 }
 } // namespace Emergence::Celerity::TransformHierarchyCleanup

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformHierarchyCleanup.hpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformHierarchyCleanup.hpp
@@ -4,22 +4,25 @@
 
 namespace Emergence::Celerity::TransformHierarchyCleanup
 {
-/// \brief Contains checkpoints, supported by tasks from ::AddToFixedUpdate and ::AddToNormalUpdate.
+/// \brief Contains checkpoints, supported by tasks from ::Add2dToFixedUpdate, ::Add3dToFixedUpdate,
+///        ::Add2dToNormalUpdate. and ::Add3dToNormalUpdate.
+/// \details For game world objects it is intuitive to treat transform components as cornerstone: if transform
+///          component is removed, then all other components and all child transforms should be recursively
+///          cleaned up too. TransformHierarchyCleanup implements this feature for transforms and leaves space
+///          for users to insert cleaners for their own components between ::CLEANUP_STARTED and ::FINISHED
+///          checkpoints. That provides centralized way to apply transform hierarchy cleanups.
 struct Checkpoint final
 {
     Checkpoint () = delete;
 
-    /// \brief Detached transform removal is executed after this checkpoint.
-    static const Memory::UniqueString DETACHED_REMOVAL_STARTED;
+    /// \brief Detached transform detection and removal is started after this checkpoint.
+    static const Memory::UniqueString STARTED;
 
-    /// \brief Detached transform removal is guaranteed to be finished after this checkpoint.
-    static const Memory::UniqueString DETACHED_REMOVAL_FINISHED;
+    /// \brief Removal of detached components is started after this checkpoint.
+    static const Memory::UniqueString CLEANUP_STARTED;
 
-    /// \brief Detached transform detection is started after this checkpoint.
-    static const Memory::UniqueString DETACHMENT_DETECTION_STARTED;
-
-    /// \brief Detached transform detection is guaranteed to be finished after this checkpoint.
-    static const Memory::UniqueString DETACHMENT_DETECTION_FINISHED;
+    /// \brief Detached transform and component detection and removal is finished before this checkpoint.
+    static const Memory::UniqueString FINISHED;
 };
 
 /// \brief Adds tasks required to cleanup detached transform 2d hierarchy to fixed update pipeline.

--- a/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformVisualSync.cpp
+++ b/Library/Public/Celerity/Extension/Transform/Celerity/Transform/TransformVisualSync.cpp
@@ -58,10 +58,9 @@ TransformVisualSynchronizer<TransformComponentType>::TransformVisualSynchronizer
       editTransformById (EDIT_VALUE_1F (TransformComponentType, objectId)),
       editTransformsWithUpdateFlag (EDIT_SIGNAL (TransformComponentType, visualTransformSyncNeeded, true))
 {
-    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.DependOn (TransformVisualSync::Checkpoint::STARTED);
     _constructor.MakeDependencyOf (TransformVisualSync::Checkpoint::FINISHED);
-    _constructor.MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::DETACHMENT_DETECTION_STARTED);
 }
 
 template <typename TransformComponentType>

--- a/Service/StandardLayoutMapping/API/StandardLayout/Mapping.hpp
+++ b/Service/StandardLayoutMapping/API/StandardLayout/Mapping.hpp
@@ -146,5 +146,3 @@ struct hash<Emergence::StandardLayout::Mapping>
     }
 };
 } // namespace std
-
-EMERGENCE_MEMORY_DEFAULT_ALLOCATION_GROUP (Emergence::StandardLayout::Mapping)

--- a/Service/StandardLayoutMapping/API/StandardLayout/Mapping.hpp
+++ b/Service/StandardLayoutMapping/API/StandardLayout/Mapping.hpp
@@ -146,3 +146,5 @@ struct hash<Emergence::StandardLayout::Mapping>
     }
 };
 } // namespace std
+
+EMERGENCE_MEMORY_DEFAULT_ALLOCATION_GROUP (Emergence::StandardLayout::Mapping)

--- a/Service/StandardLayoutMapping/Implementation/Original/StandardLayout/Mapping.cpp
+++ b/Service/StandardLayoutMapping/Implementation/Original/StandardLayout/Mapping.cpp
@@ -7,9 +7,7 @@
 
 #include <SyntaxSugar/BlockCast.hpp>
 
-namespace Emergence
-{
-namespace StandardLayout
+namespace Emergence::StandardLayout
 {
 using FieldIterator = Mapping::FieldIterator;
 
@@ -198,15 +196,4 @@ Mapping::FieldIterator end (const Mapping &_mapping) noexcept
 {
     return _mapping.End ();
 }
-} // namespace StandardLayout
-
-namespace Memory
-{
-using namespace Literals;
-
-Profiler::AllocationGroup DefaultAllocationGroup<StandardLayout::Mapping>::Get () noexcept
-{
-    return Profiler::AllocationGroup {"MappingReflection"_us};
-}
-} // namespace Memory
-} // namespace Emergence
+} // namespace Emergence::StandardLayout

--- a/Service/StandardLayoutMapping/Implementation/Original/StandardLayout/Mapping.cpp
+++ b/Service/StandardLayoutMapping/Implementation/Original/StandardLayout/Mapping.cpp
@@ -7,7 +7,9 @@
 
 #include <SyntaxSugar/BlockCast.hpp>
 
-namespace Emergence::StandardLayout
+namespace Emergence
+{
+namespace StandardLayout
 {
 using FieldIterator = Mapping::FieldIterator;
 
@@ -196,4 +198,15 @@ Mapping::FieldIterator end (const Mapping &_mapping) noexcept
 {
     return _mapping.End ();
 }
-} // namespace Emergence::StandardLayout
+} // namespace StandardLayout
+
+namespace Memory
+{
+using namespace Literals;
+
+Profiler::AllocationGroup DefaultAllocationGroup<StandardLayout::Mapping>::Get () noexcept
+{
+    return Profiler::AllocationGroup {"MappingReflection"_us};
+}
+} // namespace Memory
+} // namespace Emergence

--- a/Test/Library/Celerity/Extension/Assembly/Celerity/Assembly/Test/Assembly.cpp
+++ b/Test/Library/Celerity/Extension/Assembly/Celerity/Assembly/Test/Assembly.cpp
@@ -68,6 +68,8 @@ void FixedAssemblyTest (Container::Vector<ConfiguratorTask> _configuratorTasks,
     }
 
     PipelineBuilder builder {&world};
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
 
     Assembly::AddToFixedUpdate (builder, GetAssemblerCustomKeys (), GetFixedAssemblerTypes ());
@@ -93,12 +95,15 @@ void CombinedAssemblyTest (Container::Vector<ConfiguratorTask> _fixedConfigurato
 
     PipelineBuilder builder {&world};
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
     Assembly::AddToFixedUpdate (builder, GetAssemblerCustomKeys (), GetFixedAssemblerTypes ());
     AddConfiguratorAndValidator (builder, std::move (_fixedConfiguratorTasks), std::move (_fixedValidatorTasks));
     REQUIRE (builder.End ());
 
     builder.Begin ("NormalUpdate"_us, PipelineType::NORMAL);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
     builder.AddCheckpoint (TransformVisualSync::Checkpoint::STARTED);
     Assembly::AddToNormalUpdate (builder, GetAssemblerCustomKeys (), GetNormalAssemblerTypes ());
     AddConfiguratorAndValidator (builder, std::move (_normalConfiguratorTasks), std::move (_normalValidatorTasks));

--- a/Test/Library/Celerity/Extension/Assembly/Celerity/Assembly/Test/Task.cpp
+++ b/Test/Library/Celerity/Extension/Assembly/Celerity/Assembly/Test/Task.cpp
@@ -5,6 +5,7 @@
 #include <Celerity/Model/WorldSingleton.hpp>
 #include <Celerity/PipelineBuilderMacros.hpp>
 #include <Celerity/Transform/TransformComponent.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 
 #include <Container/StringBuilder.hpp>
 
@@ -42,6 +43,7 @@ Configurator::Configurator (TaskConstructor &_constructor, Container::Vector<Con
 
       tasks (std::move (_tasks))
 {
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Assembly::Checkpoint::STARTED);
 }
 

--- a/Test/Library/Celerity/Extension/Input/Celerity/Input/Test/Scenario.cpp
+++ b/Test/Library/Celerity/Extension/Input/Celerity/Input/Test/Scenario.cpp
@@ -115,6 +115,7 @@ SubscriptionManager::SubscriptionManager (
       subscriptionsToAdd (std::move (_subscriptionsToAdd)),
       subscriptionsToRemove (std::move (_subscriptionsToRemove))
 {
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Input::Checkpoint::ACTION_DISPATCH_STARTED);
 }
 
@@ -238,8 +239,8 @@ void ExecuteScenario (const Container::Vector<Update> &_updates,
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
 
     // Add external checkpoints to which input is connected.
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_STARTED);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     builder.AddTask ("ExpectationValidator"_us).SetExecutor<ExpectationValidator> (std::move (fixedExpectations));
     builder.AddTask ("SubscriptionManager"_us)
@@ -250,8 +251,8 @@ void ExecuteScenario (const Container::Vector<Update> &_updates,
     builder.Begin ("NormalUpdate"_us, PipelineType::NORMAL);
 
     // Add external checkpoints to which input is connected.
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_STARTED);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::CLEANUP_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     builder.AddTask ("ExternalActionInserter"_us)
         .SetExecutor<ExternalActionInserter> (std::move (normalExternalActions));

--- a/Test/Library/Celerity/Extension/Render2d/Celerity/Render/2d/Test/Scenario.cpp
+++ b/Test/Library/Celerity/Extension/Render2d/Celerity/Render/2d/Test/Scenario.cpp
@@ -172,8 +172,7 @@ ScenarioExecutor::ScenarioExecutor (TaskConstructor &_constructor, Scenario _sce
       finishedOutput (_finishedOutput)
 {
     _constructor.DependOn (AssetManagement::Checkpoint::FINISHED);
-    _constructor.MakeDependencyOf (
-        Emergence::Celerity::TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_STARTED);
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (RenderPipelineFoundation::Checkpoint::RENDER_STARTED);
     _constructor.MakeDependencyOf (TransformVisualSync::Checkpoint::STARTED);
 }

--- a/Test/Library/Celerity/Extension/Render2d/Celerity/Render/2d/Test/Scenario.cpp
+++ b/Test/Library/Celerity/Extension/Render2d/Celerity/Render/2d/Test/Scenario.cpp
@@ -428,6 +428,7 @@ void ExecuteScenario (Scenario _scenario) noexcept
         Emergence::Celerity::EventRegistrar registrar {&world};
         assetReferenceBindingEventMap = Emergence::Celerity::RegisterAssetEvents (registrar, binding);
         Emergence::Celerity::RegisterTransform2dEvents (registrar);
+        Emergence::Celerity::RegisterTransformCommonEvents (registrar);
         Emergence::Celerity::RegisterRender2dEvents (registrar);
         Emergence::Celerity::RegisterRenderFoundationEvents (registrar);
     }

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/HierarchyCleanup.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/HierarchyCleanup.cpp
@@ -26,6 +26,8 @@ void HierarchyCleanupTest (Container::Vector<RequestExecutor::RequestPacket> _sc
         {
             RegisterTransform3dEvents (registrar);
         }
+
+        RegisterTransformCommonEvents (registrar);
     }
 
     PipelineBuilder builder {&world};
@@ -36,12 +38,12 @@ void HierarchyCleanupTest (Container::Vector<RequestExecutor::RequestPacket> _sc
     if (_use2d)
     {
         TransformHierarchyCleanup::Add2dToFixedUpdate (builder);
-        RequestExecutor::Add2dToFixedUpdate (builder, std::move (_scenario), true);
+        RequestExecutor::Add2dToFixedUpdate (builder, std::move (_scenario));
     }
     else
     {
         TransformHierarchyCleanup::Add3dToFixedUpdate (builder);
-        RequestExecutor::Add3dToFixedUpdate (builder, std::move (_scenario), true);
+        RequestExecutor::Add3dToFixedUpdate (builder, std::move (_scenario));
     }
 
     REQUIRE (builder.End ());

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/HierarchyCleanup.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/HierarchyCleanup.cpp
@@ -13,7 +13,7 @@ namespace Emergence::Celerity::Test
 using namespace Memory::Literals;
 using namespace Requests;
 
-void HierarchyCleanupTest (Container::Vector<RequestExecutor::RequestPacket> _scenario, bool _use2d)
+void HierarchyCleanupTest (Container::Vector<RequestExecutor::RequestPacket> _scenario, bool _fixed, bool _use2d)
 {
     World world {"TestWorld"_us};
     {
@@ -31,26 +31,54 @@ void HierarchyCleanupTest (Container::Vector<RequestExecutor::RequestPacket> _sc
     }
 
     PipelineBuilder builder {&world};
-    builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
     const std::size_t stepCount = _scenario.size ();
-    builder.AddCheckpoint (TransformVisualSync::Checkpoint::STARTED);
 
-    if (_use2d)
+    if (_fixed)
     {
-        TransformHierarchyCleanup::Add2dToFixedUpdate (builder);
-        RequestExecutor::Add2dToFixedUpdate (builder, std::move (_scenario));
+        builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
+        builder.AddCheckpoint (TransformVisualSync::Checkpoint::STARTED);
+
+        if (_use2d)
+        {
+            TransformHierarchyCleanup::Add2dToFixedUpdate (builder);
+            RequestExecutor::Add2dToFixedUpdate (builder, std::move (_scenario));
+        }
+        else
+        {
+            TransformHierarchyCleanup::Add3dToFixedUpdate (builder);
+            RequestExecutor::Add3dToFixedUpdate (builder, std::move (_scenario));
+        }
     }
     else
     {
-        TransformHierarchyCleanup::Add3dToFixedUpdate (builder);
-        RequestExecutor::Add3dToFixedUpdate (builder, std::move (_scenario));
+        builder.Begin ("NormalUpdate"_us, PipelineType::NORMAL);
+        builder.AddCheckpoint (TransformVisualSync::Checkpoint::STARTED);
+        builder.AddCheckpoint (TransformVisualSync::Checkpoint::FINISHED);
+
+        if (_use2d)
+        {
+            TransformHierarchyCleanup::Add2dToNormalUpdate (builder);
+            RequestExecutor::Add2dToNormalUpdate (builder, std::move (_scenario));
+        }
+        else
+        {
+            TransformHierarchyCleanup::Add3dToNormalUpdate (builder);
+            RequestExecutor::Add3dToNormalUpdate (builder, std::move (_scenario));
+        }
     }
 
     REQUIRE (builder.End ());
 
     for (std::size_t index = 0u; index < stepCount; ++index)
     {
-        WorldTestingUtility::RunFixedUpdateOnce (world);
+        if (_fixed)
+        {
+            WorldTestingUtility::RunFixedUpdateOnce (world);
+        }
+        else
+        {
+            WorldTestingUtility::RunNormalUpdateOnce (world, 16000000u);
+        }
     }
 }
 
@@ -128,40 +156,78 @@ using namespace Emergence::Celerity;
 using namespace Emergence::Celerity::Test;
 using namespace Emergence::Celerity::Test::Requests;
 
-BEGIN_SUITE (HierarchyCleanup2d)
+BEGIN_SUITE (HierarchyCleanupFixed2d)
 
 TEST_CASE (OneLevel)
 {
-    HierarchyCleanupTest (ONE_LEVEL_TEST, true);
+    HierarchyCleanupTest (ONE_LEVEL_TEST, true, true);
 }
 
 TEST_CASE (MultipleLevels)
 {
-    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, true);
+    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, true, true);
 }
 
 TEST_CASE (IntermediateTransformRemoval)
 {
-    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, true);
+    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, true, true);
 }
 
 END_SUITE
 
-BEGIN_SUITE (HierarchyCleanup3d)
+BEGIN_SUITE (HierarchyCleanupNormal2d)
 
 TEST_CASE (OneLevel)
 {
-    HierarchyCleanupTest (ONE_LEVEL_TEST, false);
+    HierarchyCleanupTest (ONE_LEVEL_TEST, false, true);
 }
 
 TEST_CASE (MultipleLevels)
 {
-    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, false);
+    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, false, true);
 }
 
 TEST_CASE (IntermediateTransformRemoval)
 {
-    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, false);
+    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, false, true);
+}
+
+END_SUITE
+
+BEGIN_SUITE (HierarchyCleanupFixed3d)
+
+TEST_CASE (OneLevel)
+{
+    HierarchyCleanupTest (ONE_LEVEL_TEST, true, false);
+}
+
+TEST_CASE (MultipleLevels)
+{
+    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, true, false);
+}
+
+TEST_CASE (IntermediateTransformRemoval)
+{
+    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, true, false);
+}
+
+END_SUITE
+
+BEGIN_SUITE (HierarchyCleanupNormal3d)
+
+TEST_CASE (OneLevel)
+{
+    HierarchyCleanupTest (ONE_LEVEL_TEST, false, false);
+}
+
+TEST_CASE (MultipleLevels)
+{
+    HierarchyCleanupTest (MULTIPLE_LEVELS_TEST, false, false);
+}
+
+TEST_CASE (IntermediateTransformRemoval)
+{
+    HierarchyCleanupTest (INTERMEDIATE_TRANSFORM_REMOVAL_TEST, false, false);
 }
 
 END_SUITE

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Operation.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Operation.cpp
@@ -1,4 +1,5 @@
 #include <Celerity/Transform/Test/Task.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 
 #include <Math/Constants.hpp>
 
@@ -16,6 +17,8 @@ void OperationsTest (RequestExecutor::RequestPacket _scenario, bool _use2d)
     PipelineBuilder builder {&world};
 
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
+
     if (_use2d)
     {
         RequestExecutor::Add2dToFixedUpdate (builder, {std::move (_scenario)});

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Sync.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Sync.cpp
@@ -29,6 +29,8 @@ void SyncTest (Container::Vector<uint64_t> _timeSamples,
     PipelineBuilder builder {&world};
 
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
+
     if (_use2d)
     {
         RequestExecutor::Add2dToFixedUpdate (builder, std::move (_fixedRequests));
@@ -40,8 +42,7 @@ void SyncTest (Container::Vector<uint64_t> _timeSamples,
 
     REQUIRE (builder.End ());
     builder.Begin ("NormalUpdate"_us, PipelineType::NORMAL);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHMENT_DETECTION_STARTED);
+    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::FINISHED);
 
     if (_use2d)
     {

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
@@ -274,8 +274,7 @@ void Executor<Transform>::Execute () noexcept
     ++executionIndex;
 }
 
-void Add2dToFixedUpdate (PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests) noexcept
+void Add2dToFixedUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
     constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
@@ -289,8 +288,7 @@ void Add2dToNormalUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<R
     constructor.SetExecutor<Executor<Math::Transform2d>> (std::move (_requests));
 }
 
-void Add3dToFixedUpdate (PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests) noexcept
+void Add3dToFixedUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
     constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
@@ -284,6 +284,7 @@ void Add2dToFixedUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<Re
 void Add2dToNormalUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
+    constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     constructor.DependOn (TransformVisualSync::Checkpoint::FINISHED);
     constructor.SetExecutor<Executor<Math::Transform2d>> (std::move (_requests));
 }
@@ -298,6 +299,7 @@ void Add3dToFixedUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<Re
 void Add3dToNormalUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
+    constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     constructor.DependOn (TransformVisualSync::Checkpoint::FINISHED);
     constructor.SetExecutor<Executor<Math::Transform3d>> (std::move (_requests));
 }

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.cpp
@@ -275,16 +275,10 @@ void Executor<Transform>::Execute () noexcept
 }
 
 void Add2dToFixedUpdate (PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests,
-                         bool _withHierarchyCleanup) noexcept
+                         Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
-    if (_withHierarchyCleanup)
-    {
-        constructor.DependOn (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
-        constructor.MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::DETACHMENT_DETECTION_STARTED);
-    }
-
+    constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     constructor.SetExecutor<Executor<Math::Transform2d>> (std::move (_requests));
 }
 
@@ -296,16 +290,10 @@ void Add2dToNormalUpdate (PipelineBuilder &_pipelineBuilder, Container::Vector<R
 }
 
 void Add3dToFixedUpdate (PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests,
-                         bool _withHierarchyCleanup) noexcept
+                         Container::Vector<RequestPacket> _requests) noexcept
 {
     TaskConstructor constructor = _pipelineBuilder.AddTask (Memory::UniqueString {"TransformRequestExecutor"});
-    if (_withHierarchyCleanup)
-    {
-        constructor.DependOn (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
-        constructor.MakeDependencyOf (TransformHierarchyCleanup::Checkpoint::DETACHMENT_DETECTION_STARTED);
-    }
-
+    constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     constructor.SetExecutor<Executor<Math::Transform3d>> (std::move (_requests));
 }
 

--- a/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.hpp
+++ b/Test/Library/Celerity/Extension/Transform/Celerity/Transform/Test/Task.hpp
@@ -108,15 +108,13 @@ namespace RequestExecutor
 using RequestPacket = Container::Vector<Request>;
 
 void Add2dToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests,
-                         bool _withHierarchyCleanup = false) noexcept;
+                         Container::Vector<RequestPacket> _requests) noexcept;
 
 void Add2dToNormalUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder,
                           Container::Vector<RequestPacket> _requests) noexcept;
 
 void Add3dToFixedUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder,
-                         Container::Vector<RequestPacket> _requests,
-                         bool _withHierarchyCleanup = false) noexcept;
+                         Container::Vector<RequestPacket> _requests) noexcept;
 
 void Add3dToNormalUpdate (Emergence::Celerity::PipelineBuilder &_pipelineBuilder,
                           Container::Vector<RequestPacket> _requests) noexcept;

--- a/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Lifetime.cpp
+++ b/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Lifetime.cpp
@@ -101,7 +101,9 @@ TEST_CASE (CleanupAfterTransformRemoval)
                                  CheckCollisionShapeExistence {0u, true},
                                  CheckCollisionShapeExistence {1u, true},
                              }},
-                            {1u,
+                            // We need to give TransformHierarchyCleanup one frame of delay, because configurator is
+                            // executed right after TransformHierarchyCleanup.
+                            {2u,
                              {
                                  CheckRigidBodyExistence {0u, false},
                                  CheckRigidBodyExistence {1u, true},

--- a/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Task.cpp
+++ b/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Task.cpp
@@ -399,6 +399,7 @@ void ExecuteScenario (Container::Vector<ConfiguratorFrame> _configuratorFrames,
         EventRegistrar registrar {&world};
         RegisterPhysicsEvents (registrar);
         RegisterTransform2dEvents (registrar);
+        RegisterTransformCommonEvents (registrar);
     }
 
     PipelineBuilder builder {&world};

--- a/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Task.cpp
+++ b/Test/Service/Celerity/Extension/Physics2d/Celerity/Physics2d/Test/Task.cpp
@@ -64,6 +64,7 @@ Configurator::Configurator (TaskConstructor &_constructor, Container::Vector<Con
       insertShape (INSERT_LONG_TERM (CollisionShape2dComponent)),
       modifyShapeByShapeId (MODIFY_VALUE_1F (CollisionShape2dComponent, shapeId))
 {
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Physics2dSimulation::Checkpoint::STARTED);
 }
 
@@ -403,13 +404,9 @@ void ExecuteScenario (Container::Vector<ConfiguratorFrame> _configuratorFrames,
     }
 
     PipelineBuilder builder {&world};
-
-    // Add external checkpoints to which physics is connected.
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_STARTED);
-    builder.AddCheckpoint (TransformHierarchyCleanup::Checkpoint::DETACHED_REMOVAL_FINISHED);
-
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
     Physics2dSimulation::AddToFixedUpdate (builder);
+    TransformHierarchyCleanup::Add2dToFixedUpdate (builder);
 
     builder.AddTask ("Configurator"_us).SetExecutor<Configurator> (std::move (_configuratorFrames));
     builder.AddTask ("Validator"_us).SetExecutor<Validator> (std::move (_validatorFrames));

--- a/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Lifetime.cpp
+++ b/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Lifetime.cpp
@@ -101,7 +101,9 @@ TEST_CASE (CleanupAfterTransformRemoval)
                                  CheckCollisionShapeExistence {0u, true},
                                  CheckCollisionShapeExistence {1u, true},
                              }},
-                            {1u,
+                            // We need to give TransformHierarchyCleanup one frame of delay, because configurator is
+                            // executed right after TransformHierarchyCleanup.
+                            {2u,
                              {
                                  CheckRigidBodyExistence {0u, false},
                                  CheckRigidBodyExistence {1u, true},

--- a/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Task.cpp
+++ b/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Task.cpp
@@ -414,6 +414,7 @@ void ExecuteScenario (Container::Vector<ConfiguratorFrame> _configuratorFrames,
         EventRegistrar registrar {&world};
         RegisterPhysicsEvents (registrar);
         RegisterTransform3dEvents (registrar);
+        RegisterTransformCommonEvents (registrar);
     }
 
     PipelineBuilder builder {&world};

--- a/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Task.cpp
+++ b/Test/Service/Celerity/Extension/Physics3d/Celerity/Physics3d/Test/Task.cpp
@@ -12,6 +12,7 @@
 #include <Celerity/Physics3d/Test/Task.hpp>
 #include <Celerity/Transform/Events.hpp>
 #include <Celerity/Transform/TransformComponent.hpp>
+#include <Celerity/Transform/TransformHierarchyCleanup.hpp>
 #include <Celerity/Transform/TransformWorldAccessor.hpp>
 
 #include <Testing/Testing.hpp>
@@ -63,6 +64,7 @@ Configurator::Configurator (TaskConstructor &_constructor, Container::Vector<Con
       insertShape (INSERT_LONG_TERM (CollisionShape3dComponent)),
       modifyShapeByShapeId (MODIFY_VALUE_1F (CollisionShape3dComponent, shapeId))
 {
+    _constructor.DependOn (TransformHierarchyCleanup::Checkpoint::FINISHED);
     _constructor.MakeDependencyOf (Physics3dSimulation::Checkpoint::STARTED);
 }
 
@@ -420,6 +422,7 @@ void ExecuteScenario (Container::Vector<ConfiguratorFrame> _configuratorFrames,
     PipelineBuilder builder {&world};
     builder.Begin ("FixedUpdate"_us, PipelineType::FIXED);
     Physics3dSimulation::AddToFixedUpdate (builder);
+    TransformHierarchyCleanup::Add3dToFixedUpdate (builder);
 
     builder.AddTask ("Configurator"_us).SetExecutor<Configurator> (std::move (_configuratorFrames));
     builder.AddTask ("Validator"_us).SetExecutor<Validator> (std::move (_validatorFrames));


### PR DESCRIPTION
Now transform-related cascade removal is done through separate cleanup event instead of removal event. It allows us to cleanup everything at once during the start of the frame with minimum delays.